### PR TITLE
Update the rotate carry instructions to mask the operand value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 
+## Unreleased
+- Update the rotate carry instructions to mask the operand value (@ddash-ct)
+
+
 ## [1.3.0] - 2026-05-01
 - Updated to support latest version of Dragodis which has Vivisect support.
 - Add option to set `num_args` when setting a call hook.

--- a/src/rugosa/emulation/x86_64/opcodes.py
+++ b/src/rugosa/emulation/x86_64/opcodes.py
@@ -1448,9 +1448,11 @@ def RCR(cpu_context: ProcessorContext, instruction: Instruction):
     if opvalue2 == 1:
         cpu_context.registers.of = get_msb(opvalue1, width) ^ cpu_context.registers.cf
 
+    mask = (1 << (8 * width)) - 1
     while tempcount:
         tempcf = get_lsb(opvalue2)
         opvalue1 = (opvalue1 >> 1) + (cpu_context.registers.cf * 2 ** width)
+        opvalue1 &= mask
         cpu_context.registers.cf = tempcf
         tempcount -= 1
 
@@ -1479,9 +1481,11 @@ def RCL(cpu_context: ProcessorContext, instruction: Instruction):
         # This is undefined behavior
         return
 
+    mask = (1 << (8 * width)) - 1
     while tempcount:
         tempcf = get_msb(opvalue1, width)
         opvalue1 = (opvalue1 * 2) + cpu_context.registers.cf
+        opvalue1 &= mask
         cpu_context.registers.cf = tempcf
         tempcount -= 1
 


### PR DESCRIPTION
Update `RCR` and `RCL` instructions to properly mask the operand values